### PR TITLE
preserve attribute order with btreemap

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# runs the same set of build commands that will run in ci
+set -e
+cargo clippy -- --version && cargo fmt -- --version
+cargo fmt -- --check
+cargo clippy --locked -- -D warnings
+cargo clippy --tests --locked -- -D warnings
+cargo test --all-features
+cargo build --package exile --lib

--- a/xdoc/src/doc.rs
+++ b/xdoc/src/doc.rs
@@ -262,7 +262,7 @@ impl ToString for Document {
 macro_rules! map (
     { $($key:expr => $value:expr),+ } => {
         {
-            let mut m = ::std::collections::HashMap::new();
+            let mut m = ::std::collections::BTreeMap::new();
             $(
                 m.insert($key, $value);
             )+

--- a/xdoc/src/lib.rs
+++ b/xdoc/src/lib.rs
@@ -50,17 +50,6 @@ pub struct PIData {
     derive(Serialize, Deserialize),
     serde(rename_all = "snake_case")
 )]
-struct Attribute {
-    key: String,
-    value: String,
-}
-
-#[derive(Debug, Clone, Eq, PartialOrd, PartialEq, Hash, Default)]
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(rename_all = "snake_case")
-)]
 pub struct ElementData {
     pub namespace: Option<String>,
     pub name: String,

--- a/xdoc/src/ord_map.rs
+++ b/xdoc/src/ord_map.rs
@@ -1,25 +1,25 @@
 use core::fmt;
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
 
 // TODO - extract key and value types
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct OrdMap(HashMap<String, String>);
+pub struct OrdMap(BTreeMap<String, String>);
 
 impl OrdMap {
     pub fn new() -> Self {
-        OrdMap(HashMap::new())
+        OrdMap(BTreeMap::new())
     }
 
-    pub fn from(inner: HashMap<String, String>) -> Self {
+    pub fn from(inner: BTreeMap<String, String>) -> Self {
         OrdMap(inner)
     }
 }
 
 impl Clone for OrdMap {
     fn clone(&self) -> Self {
-        let mut result = HashMap::new();
+        let mut result = BTreeMap::new();
         for (k, v) in self.0.iter() {
             result.insert(k.clone(), v.clone());
         }
@@ -29,7 +29,7 @@ impl Clone for OrdMap {
 
 impl Default for OrdMap {
     fn default() -> Self {
-        Self(HashMap::new())
+        Self(BTreeMap::new())
     }
 }
 
@@ -54,11 +54,11 @@ impl PartialEq for OrdMap {
 impl Eq for OrdMap {}
 
 impl OrdMap {
-    pub fn map(&self) -> &HashMap<String, String> {
+    pub fn map(&self) -> &BTreeMap<String, String> {
         &self.0
     }
 
-    pub fn mut_map(&mut self) -> &mut HashMap<String, String> {
+    pub fn mut_map(&mut self) -> &mut BTreeMap<String, String> {
         &mut self.0
     }
 
@@ -137,5 +137,46 @@ impl Hash for OrdMap {
             k.hash(state);
             v.hash(state);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OrdMap;
+
+    /// Although this test does nothing but explore the behavior of a built-in data structure, it's
+    /// here to demonstrate the desired characteristic of that data structure. We want attributes to
+    /// serialize in the order that they were inserted.
+    #[test]
+    fn map_insertion_order() {
+        let mut a = OrdMap::new();
+        a.mut_map().insert("0".to_string(), String::new());
+        a.mut_map().insert("1".to_string(), String::new());
+        a.mut_map().insert("2".to_string(), String::new());
+        a.mut_map().insert("3".to_string(), String::new());
+        a.mut_map().insert("4".to_string(), String::new());
+        let entries = a.map().keys();
+        for (i, item) in entries.enumerate() {
+            assert_eq!(format!("{}", i), item.to_owned());
+        }
+    }
+
+    /// This test demonstrates that two maps containing the same entries are equal irrespective of
+    /// insertion order.
+    #[test]
+    fn map_equality() {
+        let mut a = OrdMap::new();
+        a.mut_map().insert("0".to_string(), "a".to_string());
+        a.mut_map().insert("1".to_string(), "b".to_string());
+        a.mut_map().insert("2".to_string(), "c".to_string());
+        a.mut_map().insert("3".to_string(), "d".to_string());
+        a.mut_map().insert("4".to_string(), "e".to_string());
+        let mut b = OrdMap::new();
+        b.mut_map().insert("4".to_string(), "e".to_string());
+        b.mut_map().insert("3".to_string(), "d".to_string());
+        b.mut_map().insert("1".to_string(), "b".to_string());
+        b.mut_map().insert("2".to_string(), "c".to_string());
+        b.mut_map().insert("0".to_string(), "a".to_string());
+        assert_eq!(a, b);
     }
 }


### PR DESCRIPTION
Closes #2 
Use a BTreeMap for attributes to preserve insertion order.