### PR TITLE
Ignore unimplemented nodes

### DIFF
--- a/exile/src/parser/element.rs
+++ b/exile/src/parser/element.rs
@@ -1,9 +1,9 @@
 use xdoc::{ElementData, Node, OrdMap};
 
 use crate::error::Result;
-use crate::parser::chars::{is_name_char, is_name_start_char};
+use crate::parser::chars::is_name_start_char;
 use crate::parser::string::{parse_string, StringType};
-use crate::parser::{parse_name, skip_comment, skip_processing_instruction, Iter, ParserState};
+use crate::parser::{parse_name, skip_comment, skip_processing_instruction, Iter};
 
 pub(crate) fn parse_element(iter: &mut Iter) -> Result<ElementData> {
     expect!(iter, '<')?;
@@ -128,10 +128,8 @@ fn parse_children(iter: &mut Iter, parent: &mut ElementData) -> Result<()> {
             let text = parse_text(iter)?;
             parent.nodes.push(Node::String(text));
         }
-        if !iter.is('<') {
-            if !iter.advance() {
-                break;
-            }
+        if !iter.is('<') && !iter.advance() {
+            break;
         }
     }
     Ok(())

--- a/exile/src/parser/element.rs
+++ b/exile/src/parser/element.rs
@@ -98,7 +98,6 @@ fn parse_attribute_value(iter: &mut Iter) -> Result<String> {
 }
 
 fn parse_children(iter: &mut Iter, parent: &mut ElementData) -> Result<()> {
-    // TODO(https://github.com/webern/exile/issues/8) - refactor this loop
     loop {
         iter.skip_whitespace()?;
         if iter.is('<') {
@@ -112,18 +111,11 @@ fn parse_children(iter: &mut Iter, parent: &mut ElementData) -> Result<()> {
         } else {
             let text = parse_text(iter)?;
             parent.nodes.push(Node::String(text));
-            if iter.is('<') {
-                // TODO(https://github.com/webern/exile/issues/8)  - this nested call to handle_left_angle is stupid
-                if let Some(node) = handle_left_angle(iter, parent)? {
-                    parent.nodes.push(node);
-                } else {
-                    // we received 'None' which means that the end tag was parsed
-                    return Ok(());
-                }
-            }
         }
-        if !iter.advance() {
-            break;
+        if !iter.is('<') {
+            if !iter.advance() {
+                break;
+            }
         }
     }
     Ok(())

--- a/exile/src/parser/element.rs
+++ b/exile/src/parser/element.rs
@@ -1,8 +1,9 @@
 use xdoc::{ElementData, Node, OrdMap};
 
 use crate::error::Result;
+use crate::parser::chars::{is_name_char, is_name_start_char};
 use crate::parser::string::{parse_string, StringType};
-use crate::parser::{parse_name, Iter};
+use crate::parser::{parse_name, skip_comment, skip_processing_instruction, Iter, ParserState};
 
 pub(crate) fn parse_element(iter: &mut Iter) -> Result<ElementData> {
     expect!(iter, '<')?;
@@ -97,16 +98,31 @@ fn parse_attribute_value(iter: &mut Iter) -> Result<String> {
     parse_string(iter, StringType::Attribute)
 }
 
+enum LTParse {
+    /// The parsed entity was an EndTag.
+    EndTag,
+    /// The parsed entity was an unsupported node type, i.e. something we want to skip.
+    Skip,
+    /// The parsed entity was a supported node type.
+    Some(Node),
+}
+
 fn parse_children(iter: &mut Iter, parent: &mut ElementData) -> Result<()> {
     loop {
         iter.skip_whitespace()?;
         if iter.is('<') {
-            if let Some(node) = handle_left_angle(iter, parent)? {
-                parent.nodes.push(node);
-            } else {
-                // TODO(https://github.com/webern/exile/issues/8)  - receiving 'None' is not going to work
-                // we received 'None' which means that the end tag was parsed
-                return Ok(());
+            let lt_parse = parse_lt(iter, parent)?;
+            match lt_parse {
+                LTParse::EndTag => {
+                    // this is the recursion's breaking condition
+                    return Ok(());
+                }
+                LTParse::Skip => {
+                    // do nothing
+                }
+                LTParse::Some(node) => {
+                    parent.nodes.push(node);
+                }
             }
         } else {
             let text = parse_text(iter)?;
@@ -121,26 +137,38 @@ fn parse_children(iter: &mut Iter, parent: &mut ElementData) -> Result<()> {
     Ok(())
 }
 
-// TODO(https://github.com/webern/exile/issues/8)  - this function is problematic as it is ignorent of comments and pis
-fn handle_left_angle(iter: &mut Iter, parent: &mut ElementData) -> Result<Option<Node>> {
-    if iter.peek_is('/') {
-        let end_tag_name = parse_end_tag_name(iter)?;
-        if end_tag_name != parent.fullname() {
-            return parse_err!(
-                iter,
-                "closing element name '{}' does not match openeing element name '{}'",
-                end_tag_name,
-                parent.fullname()
-            );
-        }
-        // return None to signal that we have parsed and end tag
-        return Ok(None);
+fn parse_lt(iter: &mut Iter, parent: &mut ElementData) -> Result<LTParse> {
+    let next = iter.peek_or_die()?;
+    // do the most common, hottest path first
+    if is_name_start_char(next) {
+        let element = parse_element(iter)?;
+        return Ok(LTParse::Some(Node::Element(element)));
     }
-    let element = parse_element(iter)?;
-    Ok(Some(Node::Element(element)))
+    match next {
+        '/' => {
+            parse_end_tag_name(iter, parent)?;
+            Ok(LTParse::EndTag)
+        }
+        '?' => {
+            skip_processing_instruction(iter)?;
+            Ok(LTParse::Skip)
+        }
+        '!' => {
+            // skip comment expects the iter to be advanced passed lt
+            iter.advance_or_die()?;
+            skip_comment(iter)?;
+            Ok(LTParse::Skip)
+        }
+        _ => {
+            // this error occurred on the peeked char, so to report the correct position of the
+            // error, we will first advance the iter (if possible).
+            iter.advance();
+            parse_err!(iter, "unexpected char following '<'")
+        }
+    }
 }
 
-fn parse_end_tag_name(iter: &mut Iter) -> Result<String> {
+fn parse_end_tag_name(iter: &mut Iter, parent: &ElementData) -> Result<()> {
     expect!(iter, '<')?;
     iter.advance_or_die()?;
     expect!(iter, '/')?;
@@ -161,7 +189,15 @@ fn parse_end_tag_name(iter: &mut Iter) -> Result<String> {
     }
     iter.skip_whitespace()?;
     expect!(iter, '>')?;
-    Ok(name)
+    if name != parent.fullname() {
+        return parse_err!(
+            iter,
+            "closing element name '{}' does not match openeing element name '{}'",
+            name,
+            parent.fullname()
+        );
+    }
+    Ok(())
 }
 
 fn parse_text(iter: &mut Iter) -> Result<String> {

--- a/exile/src/parser/element.rs
+++ b/exile/src/parser/element.rs
@@ -98,13 +98,14 @@ fn parse_attribute_value(iter: &mut Iter) -> Result<String> {
 }
 
 fn parse_children(iter: &mut Iter, parent: &mut ElementData) -> Result<()> {
-    // TODO - support comments, processing instructions and whatever else
+    // TODO(https://github.com/webern/exile/issues/8) - refactor this loop
     loop {
         iter.skip_whitespace()?;
         if iter.is('<') {
             if let Some(node) = handle_left_angle(iter, parent)? {
                 parent.nodes.push(node);
             } else {
+                // TODO(https://github.com/webern/exile/issues/8)  - receiving 'None' is not going to work
                 // we received 'None' which means that the end tag was parsed
                 return Ok(());
             }
@@ -112,6 +113,7 @@ fn parse_children(iter: &mut Iter, parent: &mut ElementData) -> Result<()> {
             let text = parse_text(iter)?;
             parent.nodes.push(Node::String(text));
             if iter.is('<') {
+                // TODO(https://github.com/webern/exile/issues/8)  - this nested call to handle_left_angle is stupid
                 if let Some(node) = handle_left_angle(iter, parent)? {
                     parent.nodes.push(node);
                 } else {
@@ -127,6 +129,7 @@ fn parse_children(iter: &mut Iter, parent: &mut ElementData) -> Result<()> {
     Ok(())
 }
 
+// TODO(https://github.com/webern/exile/issues/8)  - this function is problematic as it is ignorent of comments and pis
 fn handle_left_angle(iter: &mut Iter, parent: &mut ElementData) -> Result<Option<Node>> {
     if iter.peek_is('/') {
         let end_tag_name = parse_end_tag_name(iter)?;

--- a/exile/src/parser/mod.rs
+++ b/exile/src/parser/mod.rs
@@ -149,6 +149,7 @@ impl<'a> Iter<'a> {
         if self.is_name_start_char() {
             Ok(())
         } else {
+            // TODO(https://github.com/webern/exile/issues/8)  - this error occurs if a comment or pi is encountered
             parse_err!(self, "expected name start char, found '{}'", self.st.c)
         }
     }

--- a/exile/src/parser/mod.rs
+++ b/exile/src/parser/mod.rs
@@ -197,6 +197,14 @@ impl<'a> Iter<'a> {
         }
         (self.st.c >= 'A' && self.st.c <= 'F') || (self.st.c >= 'a' && self.st.c <= 'f')
     }
+
+    pub(crate) fn peek_or_die(&mut self) -> Result<char> {
+        let opt = self.it.peek();
+        match opt {
+            Some(c) => Ok(*c),
+            None => raise!(""),
+        }
+    }
 }
 
 pub fn parse_str(s: &str) -> Result<Document> {
@@ -258,7 +266,7 @@ fn parse_document(iter: &mut Iter, document: &mut Document) -> Result<()> {
             continue;
         }
         expect!(iter, '<')?;
-        let next = peek_or_die(iter)?;
+        let next = iter.peek_or_die()?;
         match next {
             '?' => match iter.st.doc_status {
                 DocStatus::BeforeDeclaration => parse_declaration_pi(iter, document)?,
@@ -333,14 +341,6 @@ fn state_must_be_before_declaration(iter: &Iter) -> Result<()> {
         return raise!("");
     } else {
         Ok(())
-    }
-}
-
-pub(crate) fn peek_or_die(iter: &mut Iter) -> Result<char> {
-    let opt = iter.it.peek();
-    match opt {
-        Some(c) => Ok(*c),
-        None => raise!(""),
     }
 }
 

--- a/exile/src/parser/mod.rs
+++ b/exile/src/parser/mod.rs
@@ -149,7 +149,6 @@ impl<'a> Iter<'a> {
         if self.is_name_start_char() {
             Ok(())
         } else {
-            // TODO(https://github.com/webern/exile/issues/8)  - this error occurs if a comment or pi is encountered
             parse_err!(self, "expected name start char, found '{}'", self.st.c)
         }
     }

--- a/exile/src/parser/mod.rs
+++ b/exile/src/parser/mod.rs
@@ -198,6 +198,7 @@ impl<'a> Iter<'a> {
         (self.st.c >= 'A' && self.st.c <= 'F') || (self.st.c >= 'a' && self.st.c <= 'f')
     }
 
+    // returns either the next char, or an error if the iter is at the end.
     pub(crate) fn peek_or_die(&mut self) -> Result<char> {
         let opt = self.it.peek();
         match opt {
@@ -251,11 +252,6 @@ impl Default for DocStatus {
         DocStatus::BeforeDeclaration
     }
 }
-/*
-
-prolog	   ::=   	XMLDecl Misc* (doctypedecl Misc*)?
-Misc	   ::=   	Comment | PI | S (S is whitespace)
-*/
 
 fn parse_document(iter: &mut Iter, document: &mut Document) -> Result<()> {
     loop {
@@ -294,6 +290,8 @@ fn parse_document(iter: &mut Iter, document: &mut Document) -> Result<()> {
     Ok(())
 }
 
+// takes the iter pointing to '<' and already expected to be '<?xml ...'. parses this and places
+// the values found into the mutable document parameter
 fn parse_declaration_pi(iter: &mut Iter, document: &mut Document) -> Result<()> {
     state_must_be_before_declaration(iter)?;
     let pi_data = parse_pi(iter)?;
@@ -362,17 +360,9 @@ fn parse_name(iter: &mut Iter) -> Result<String> {
     Ok(name)
 }
 
-pub(crate) fn skip_doctype(iter: &mut Iter) -> Result<()> {
-    expect!(iter, '!')?;
-    while !iter.is('>') {
-        if iter.is('[') {
-            skip_nested_doctype_stuff(iter)?
-        }
-        iter.advance_or_die()?;
-    }
-    Ok(())
-}
-
+// takes the iter after a '<' and when it is pointing at a '!'. returns when '-->' is encountered.
+// will not work if the node being parsed is a DOCTYPE, you must already know it to be a comment.
+// TODO - support comments https://github.com/webern/exile/issues/27
 pub(crate) fn skip_comment(iter: &mut Iter) -> Result<()> {
     expect!(iter, '!')?;
     iter.advance_or_die()?;
@@ -394,6 +384,23 @@ pub(crate) fn skip_comment(iter: &mut Iter) -> Result<()> {
     Ok(())
 }
 
+// takes the iter after a '<' and when it is pointing at a '!'. returns when '>' is encountered.
+// will not work if the node being parsed is a comment, you must already know it to be a DOCTYPE
+// TODO - support doctypes https://github.com/webern/exile/issues/22
+pub(crate) fn skip_doctype(iter: &mut Iter) -> Result<()> {
+    expect!(iter, '!')?;
+    while !iter.is('>') {
+        if iter.is('[') {
+            skip_nested_doctype_stuff(iter)?
+        }
+        iter.advance_or_die()?;
+    }
+    Ok(())
+}
+
+// takes the iter when it is inside if a <!DOCTYPE construct and has encountered the '[' char.
+// ignores everything and returns the iter when it is pointing to the first encountered ']'
+// TODO - support doctypes https://github.com/webern/exile/issues/22
 pub(crate) fn skip_nested_doctype_stuff(iter: &mut Iter) -> Result<()> {
     expect!(iter, '[')?;
     iter.advance_or_die()?;
@@ -403,6 +410,9 @@ pub(crate) fn skip_nested_doctype_stuff(iter: &mut Iter) -> Result<()> {
     Ok(())
 }
 
+// takes the iter pointing to the lt of a processing instruction, skips the contents and returns
+// iter pointing to the closing gt.
+// TODO - support processing instructions https://github.com/webern/exile/issues/12
 pub(crate) fn skip_processing_instruction(iter: &mut Iter) -> Result<()> {
     expect!(iter, '<')?;
     iter.advance_or_die()?;

--- a/exile/tests/parse_tests.rs
+++ b/exile/tests/parse_tests.rs
@@ -76,3 +76,13 @@ fn good_syntax_ezfile_test() {
         }
     }
 }
+
+#[test]
+fn good_syntax_doctypes_comments_pis_test() {
+    let info = xtest::load("doctypes-comments-pis");
+    let xml_str = info.read_xml_file();
+    let parse_result = exile::parse_str(xml_str.as_str());
+    if let Err(e) = parse_result {
+        panic!("expected parse_result to be Ok, got Err: {}", e);
+    }
+}

--- a/xtest/data/doctypes-comments-pis.metadata.json
+++ b/xtest/data/doctypes-comments-pis.metadata.json
@@ -1,0 +1,6 @@
+{
+  "description": "a file with doctypes, processing instructions and comments",
+  "syntax": {
+    "good": {}
+  }
+}

--- a/xtest/data/doctypes-comments-pis.xml
+++ b/xtest/data/doctypes-comments-pis.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!-- comment before doctype -->
+<?pi before doctype ?>
+<!DOCTYPE note [
+<!ELEMENT note (to,from,heading,body)>
+<!ELEMENT to (#PCDATA)>
+<!ELEMENT from (#PCDATA)>
+<!ELEMENT heading (#PCDATA)>
+<!ELEMENT body (#PCDATA)>
+]>
+<!-- comment after doctype -->
+<?pi after doctype ?>
+<note>
+    <!-- comment as element node -->
+    <to>Tove</to>
+    <from>Jani<?pi in element ?></from>
+    <heading>Reminder</heading>
+    <body>Don't forget me this weekend</body>
+</note>
+<!-- at the end -->
+<?pi at the end ?>

--- a/xtest/data/escapes.metadata.json
+++ b/xtest/data/escapes.metadata.json
@@ -26,7 +26,7 @@
         {
           "element": {
             "namespace": null,
-            "name": "b",
+            "name": "_b",
             "attributes": {
               "x": "&"
             },

--- a/xtest/data/escapes.xml
+++ b/xtest/data/escapes.xml
@@ -4,6 +4,6 @@
   >
   <a s = "&lt;&#128515;&gt;"
   />
-  <b x
-    ="&amp;">&apos;&quot;&#38;</b>
+  <_b x
+    ="&amp;">&apos;&quot;&#38;</_b>
 </escapes>


### PR DESCRIPTION
Closes #7 
Closes #8 
For now, skip doctype, processing instruction and comment nodes.