### PR TITLE
exile: support single-quoted attributes

### DIFF
--- a/BRANCH-CODEGEN.md
+++ b/BRANCH-CODEGEN.md
@@ -1,0 +1,4 @@
+
+The purpose of the [codegen](https://github.com/webern/exile/tree/codegen/exile) branch is to support [mx](https://github.com/webern/mx/tree/master/CodeGen).
+Stuff from this branch will probably find its way to the main branch.
+This branch may be force-pushed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Currently we are using v0.0.x where every version can and will contain breaking changes.
 
 ## [Unreleased]
+### Added
+- Support for single-quoted attributes [#58]
+- `exile::load` for loading files [#58]
+
+[#58]: https://github.com/webern/exile/pull/58
 
 ## [v0.0.1] - 2020-07-18
 ### Added

--- a/exile/src/lib.rs
+++ b/exile/src/lib.rs
@@ -77,7 +77,7 @@ structures and serialize them back.
 */
 
 #![deny(rust_2018_idioms)]
-#![deny(missing_docs)]
+#![deny(missing_docs, unused_imports)]
 
 use std::path::Path;
 pub use xdoc::{Document, Element, Node};

--- a/exile/src/lib.rs
+++ b/exile/src/lib.rs
@@ -79,6 +79,7 @@ structures and serialize them back.
 #![deny(rust_2018_idioms)]
 #![deny(missing_docs)]
 
+use std::path::Path;
 pub use xdoc::{Document, Element, Node};
 
 /// The `error` module defines the error types for this library.
@@ -86,10 +87,14 @@ pub use xdoc::{Document, Element, Node};
 pub mod error;
 mod parser;
 
-/// Currently this is the only way to parse an XML document.
 /// TODO - streaming https://github.com/webern/exile/issues/20
 pub fn parse(xml: &str) -> crate::error::Result<Document> {
     parser::document_from_string(xml)
+}
+
+/// Load a document from a file.
+pub fn load<P: AsRef<Path>>(path: P) -> crate::error::Result<Document> {
+    parser::document_from_file(path)
 }
 
 #[test]

--- a/exile/src/parser/mod.rs
+++ b/exile/src/parser/mod.rs
@@ -8,6 +8,7 @@ use crate::error::{display_char, parse_err, Error, ParseError, Result, ThrowSite
 use crate::parser::chars::{is_name_char, is_name_start_char};
 use crate::parser::element::parse_element;
 use crate::parser::pi::{parse_pi, parse_pi_logic};
+use std::path::Path;
 
 mod chars;
 mod element;
@@ -213,8 +214,8 @@ impl<'a> Iter<'a> {
     }
 }
 
-pub(crate) fn document_from_string(s: &str) -> crate::error::Result<Document> {
-    let mut iter = crate::parser::Iter::new(s)?;
+pub(crate) fn document_from_string<S: AsRef<str>>(s: S) -> crate::error::Result<Document> {
+    let mut iter = crate::parser::Iter::new(s.as_ref())?;
     let mut document = Document::new();
     loop {
         parse_document(&mut iter, &mut document)?;
@@ -223,6 +224,15 @@ pub(crate) fn document_from_string(s: &str) -> crate::error::Result<Document> {
         }
     }
     Ok(document)
+}
+
+pub(crate) fn document_from_file<P: AsRef<Path>>(path: P) -> crate::error::Result<Document> {
+    let s = wrap!(
+        std::fs::read_to_string(path.as_ref()),
+        "Unable to read file '{}'",
+        path.as_ref().display()
+    )?;
+    document_from_string(s)
 }
 
 // TODO - disallow dead code

--- a/exile/tests/parse_tests.rs
+++ b/exile/tests/parse_tests.rs
@@ -152,6 +152,29 @@ fn good_syntax_simple_musicxml_test() {
 }
 
 #[test]
+/// a simple file with single-quoted attributes
+fn good_syntax_single_quotes_test() {
+    let info = xtest::load("single_quotes");
+    let xml_str = info.read_xml_file();
+    let parse_result = exile::parse(xml_str.as_str());
+    if let Err(e) = parse_result {
+        panic!("expected parse_result to be Ok, got Err: {}", e);
+    }
+    let got_doc = parse_result.as_ref().unwrap();
+    let want_doc = info.metadata.expected.as_ref().unwrap();
+    let equal = want_doc == got_doc;
+    if !equal {
+        let want = want_doc.to_string();
+        let got = got_doc.to_string();
+        if want != got {
+            assert_eq!(got, want);
+        } else {
+            assert!(equal);
+        }
+    }
+}
+
+#[test]
 /// unescaped angle bracket inside element text
 fn bad_syntax_unescaped_angle_test() {
     let info = xtest::load("unescaped-angle");

--- a/xtest/data/single_quotes.metadata.json
+++ b/xtest/data/single_quotes.metadata.json
@@ -1,0 +1,21 @@
+{
+  "description": "a simple file with single-quoted attributes",
+  "syntax": {
+    "good": {}
+  },
+  "expected": {
+    "declaration": {
+      "version": "one_dot_one",
+      "encoding": "utf8"
+    },
+    "root": {
+      "namespace": null,
+      "name": "foo",
+      "attributes": {
+        "attr1": "bones",
+        "attr2": "bish"
+      },
+      "nodes": []
+    }
+  }
+}

--- a/xtest/data/single_quotes.xml
+++ b/xtest/data/single_quotes.xml
@@ -1,0 +1,2 @@
+<?xml version='1.1' encoding="UTF-8"?>
+<foo attr1="bones" attr2='bish'/>

--- a/xtest/src/io.rs
+++ b/xtest/src/io.rs
@@ -57,7 +57,8 @@ fn load_impl(test_name: &str, dir: &PathBuf) -> XmlFile {
 }
 
 fn load_metadata(p: PathBuf) -> Metadata {
-    let file = File::open(p).unwrap();
+    let file =
+        File::open(&p).unwrap_or_else(|e| panic!("Unable to load '{}: {:?}'", p.display(), e));
     let reader = BufReader::new(file);
     serde_json::from_reader(reader).unwrap()
 }


### PR DESCRIPTION
Closes #43 

Adds support for single-quoted-attributes.
Also adds a function for loading from a file.