### PR TITLE
xdoc: use options in document declaration struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ Currently we are using v0.0.x where every version can and will contain breaking 
 - Support for single-quoted attributes [#58]
 - `exile::load` for loading files [#58]
 
+### Changed
+- The `xdoc` `Version` and `Encoding` enums were weird, changed to remove `None` [#59]
+
 [#58]: https://github.com/webern/exile/pull/58
+[#59]: https://github.com/webern/exile/pull/59
 
 ## [v0.0.1] - 2020-07-18
 ### Added

--- a/exile/src/parser/mod.rs
+++ b/exile/src/parser/mod.rs
@@ -145,10 +145,7 @@ impl<'a> Iter<'a> {
         if self.is_whitespace() {
             return true;
         }
-        match self.st.c {
-            ' ' | '\t' | '=' | '/' | '>' | '\n' => true,
-            _ => false,
-        }
+        matches!(self.st.c, ' ' | '\t' | '=' | '/' | '>' | '\n')
     }
 
     pub(crate) fn expect_name_start_char(&self) -> Result<()> {
@@ -341,10 +338,10 @@ fn parse_declaration(target: &str, instructions: &[String]) -> Result<Declaratio
     if let Some(&val) = map.get("version") {
         match val {
             "1.0" => {
-                declaration.version = Version::One;
+                declaration.version = Some(Version::V10);
             }
             "1.1" => {
-                declaration.version = Version::OneDotOne;
+                declaration.version = Some(Version::V11);
             }
             _ => {
                 return raise!("");
@@ -354,7 +351,7 @@ fn parse_declaration(target: &str, instructions: &[String]) -> Result<Declaratio
     if let Some(&val) = map.get("encoding") {
         match val {
             "UTF-8" => {
-                declaration.encoding = Encoding::Utf8;
+                declaration.encoding = Some(Encoding::Utf8);
             }
             _ => {
                 return raise!("");

--- a/xtest/data/cd_catalog.metadata.json
+++ b/xtest/data/cd_catalog.metadata.json
@@ -5,7 +5,7 @@
   },
   "expected": {
     "declaration": {
-      "version": "one",
+      "version": "v10",
       "encoding": "utf8"
     },
     "root": {

--- a/xtest/data/escapes.metadata.json
+++ b/xtest/data/escapes.metadata.json
@@ -5,8 +5,8 @@
   },
   "expected": {
     "declaration": {
-      "version": "one",
-      "encoding": "none"
+      "version": "v10",
+      "encoding": null
     },
     "root": {
       "namespace": null,

--- a/xtest/data/ezfile.metadata.json
+++ b/xtest/data/ezfile.metadata.json
@@ -5,7 +5,7 @@
   },
   "expected": {
     "declaration": {
-      "version": "one",
+      "version": "v10",
       "encoding": "utf8"
     },
     "root": {

--- a/xtest/data/pi.metadata.json
+++ b/xtest/data/pi.metadata.json
@@ -5,7 +5,7 @@
   },
   "expected": {
     "declaration": {
-      "version": "one_dot_one",
+      "version": "v11",
       "encoding": "utf8"
     },
     "prolog_misc": [

--- a/xtest/data/simple_musicxml.metadata.json
+++ b/xtest/data/simple_musicxml.metadata.json
@@ -5,7 +5,7 @@
   },
   "expected": {
     "declaration": {
-      "version": "one",
+      "version": "v10",
       "encoding": "utf8"
     },
     "root": {

--- a/xtest/data/single_quotes.metadata.json
+++ b/xtest/data/single_quotes.metadata.json
@@ -5,7 +5,7 @@
   },
   "expected": {
     "declaration": {
-      "version": "one_dot_one",
+      "version": "v11",
       "encoding": "utf8"
     },
     "root": {

--- a/xtest/src/main.rs
+++ b/xtest/src/main.rs
@@ -21,8 +21,8 @@ fn main() {
 
     let mut doc = Document::new();
     doc.set_declaration(Declaration {
-        version: Version::OneDotOne,
-        encoding: Encoding::Utf8,
+        version: Some(Version::V11),
+        encoding: Some(Encoding::Utf8),
     });
     doc.push_prolog_misc(Misc::PI(PI {
         target: "a".to_owned(),


### PR DESCRIPTION
The XML Version and Encoding enums were weird because they
both had a None variant. Instead these should have been
held as Option variants.